### PR TITLE
Teleport home

### DIFF
--- a/pyquaticus/base_policies/base.py
+++ b/pyquaticus/base_policies/base.py
@@ -82,7 +82,6 @@ class BaseAgentPolicy:
 
         # Copy this agents state from the observation
         my_obs = obs[self.id]
-        print(my_obs)
         self.speed = my_obs["speed"]
         self.on_sides = my_obs["on_side"]
         self.has_flag = my_obs["has_flag"]

--- a/pyquaticus/base_policies/base.py
+++ b/pyquaticus/base_policies/base.py
@@ -82,10 +82,12 @@ class BaseAgentPolicy:
 
         # Copy this agents state from the observation
         my_obs = obs[self.id]
+        print(my_obs)
         self.speed = my_obs["speed"]
         self.on_sides = my_obs["on_side"]
         self.has_flag = my_obs["has_flag"]
         self.tagging_cooldown = my_obs["tagging_cooldown"]
+        self.is_tagged = my_obs["is_tagged"]
 
         # Calculate the rectangular coordinates for the flags location relative to the agent.
         self.my_flag_loc = (

--- a/pyquaticus/base_policies/base_attack.py
+++ b/pyquaticus/base_policies/base_attack.py
@@ -74,8 +74,11 @@ class BaseAttacker(BaseAgentPolicy):
         my_obs = self.update_state(obs)
 
         if self.mode == "easy":
+            # If tagged return home to untag
+            if self.is_tagged:
+                goal_vect = self.bearing_to_vec(my_obs["protect_flag_bearing"])
             # If I or someone on my team has the flag, go back home
-            if self.has_flag or self.my_team_has_flag:
+            elif self.has_flag or self.my_team_has_flag:
                 goal_vect = self.bearing_to_vec(my_obs["protect_flag_bearing"])
             # Otherwise go get the opponents flag
             else:
@@ -99,8 +102,11 @@ class BaseAttacker(BaseAgentPolicy):
                 act_index = 12
 
         elif self.mode == "medium":
+            
+            if self.is_tagged:
+                my_action = self.bearing_to_vec(my_obs["protect_flag_bearing"])
             # If I or someone on my team has the flag, return to my side.
-            if self.has_flag or self.my_team_has_flag:
+            elif self.has_flag or self.my_team_has_flag:
                 # Weighted to follow goal more than avoiding others
                 goal_vect = np.multiply(
                     2.00, self.bearing_to_vec(my_obs["protect_flag_bearing"])
@@ -181,9 +187,10 @@ class BaseAttacker(BaseAgentPolicy):
 
             # Increase the avoidance threshold to start avoiding when farther away
             avoid_thresh = 30.0
-
+            if self.is_tagged:
+                my_action = self.bearing_to_vec(my_obs["protect_flag_bearing"])
             # If I or someone on my team has the flag, go back to my side
-            if self.has_flag or self.my_team_has_flag:
+            elif self.has_flag or self.my_team_has_flag:
                 goal_vect = np.multiply(
                     1.25, self.bearing_to_vec(my_obs["protect_flag_bearing"])
                 )

--- a/pyquaticus/base_policies/base_defend.py
+++ b/pyquaticus/base_policies/base_defend.py
@@ -101,8 +101,11 @@ class BaseDefender(BaseAgentPolicy):
 
         elif self.mode == "medium":
             my_flag_vec = self.bearing_to_vec(my_obs["protect_flag_bearing"])
+            #If tagged return to untag
+            if self.is_tagged:
+                ag_vect = self.bearing_to_vec(my_obs["protect_flag_bearing"])
             # If the blue team doesn't have the flag, guard it
-            if self.opp_team_has_flag:
+            elif self.opp_team_has_flag:
                 # If the blue team has the flag, chase them
                 ag_vect = my_flag_vec
 
@@ -216,6 +219,10 @@ class BaseDefender(BaseAgentPolicy):
 
             act_index = 16
 
+            #If tagged return to untag
+            if self.is_tagged:
+                ag_vect = self.bearing_to_vec(my_obs["protect_flag_bearing"])
+                
             # Modified to use fastest speed and make big turns use a slower speed to increase turning radius
             try:
                 act_heading = self.angle180(self.vec_to_heading(ag_vect))

--- a/pyquaticus/base_policies/base_defend.py
+++ b/pyquaticus/base_policies/base_defend.py
@@ -79,8 +79,12 @@ class BaseDefender(BaseAgentPolicy):
         if self.mode == "easy":
             ag_vect = [0, 0]
             my_flag_vec = self.bearing_to_vec(my_obs["protect_flag_bearing"])
+            
+            #If tagged return to untag
+            if self.is_tagged:
+                ag_vect = self.bearing_to_vec(my_obs["protect_flag_bearing"])
             # If far away from the flag, move towards it
-            if my_obs["protect_flag_distance"] > (
+            elif my_obs["protect_flag_distance"] > (
                 self.flag_keepout + self.catch_radius + 1.0
             ):
                 ag_vect = my_flag_vec
@@ -89,6 +93,7 @@ class BaseDefender(BaseAgentPolicy):
             else:
                 ag_vect = np.multiply(-1.0, my_flag_vec)
 
+            
             act_index = 12
             act_heading = self.angle180(self.vec_to_heading(ag_vect))
 
@@ -222,7 +227,7 @@ class BaseDefender(BaseAgentPolicy):
             #If tagged return to untag
             if self.is_tagged:
                 ag_vect = self.bearing_to_vec(my_obs["protect_flag_bearing"])
-                
+
             # Modified to use fastest speed and make big turns use a slower speed to increase turning radius
             try:
                 act_heading = self.angle180(self.vec_to_heading(ag_vect))

--- a/pyquaticus/base_policies/base_policies.py
+++ b/pyquaticus/base_policies/base_policies.py
@@ -234,14 +234,14 @@ def CombinedGen(agentid, team, mode, team_size):
     return CombinedPolicy
 
 # Function to create the normalizer for observations
-def register_state_elements(team_size):
+def register_state_elements(self):
     """Initializes the normalizer."""
     agent_obs_normalizer = ObsNormalizer(True)
     max_bearing = [180]
-    max_dist = [np.linalg.norm(pyq.config_dict_std["world_size"]) + 10]  # add a ten meter buffer
+    max_dist = [np.linalg.norm(self.world_size) + 10]  # add a ten meter buffer
     min_dist = [0.0]
     max_bool, min_bool = [1.0], [0.0]
-    max_speed, min_speed = [pyq.config_dict_std["max_speed"]], [0.0]
+    max_speed, min_speed = [self.max_speed], [0.0]
     agent_obs_normalizer.register("retrieve_flag_bearing", max_bearing)
     agent_obs_normalizer.register("retrieve_flag_distance", max_dist, min_dist)
     agent_obs_normalizer.register("protect_flag_bearing", max_bearing)
@@ -258,10 +258,13 @@ def register_state_elements(team_size):
     agent_obs_normalizer.register("has_flag", max_bool, min_bool)
     agent_obs_normalizer.register("on_side", max_bool, min_bool)
     agent_obs_normalizer.register(
-        "tagging_cooldown", [pyq.config_dict_std["tagging_cooldown"]], [0.0]
+        "tagging_cooldown", [self.tagging_cooldown], [0.0]
     )
-
-    num_on_team = team_size
+    agent_obs_normalizer.register("is_tagged", max_bool, min_bool)
+    assert len(self.agents_of_team[Team.BLUE_TEAM]) == len(
+        self.agents_of_team[Team.RED_TEAM]
+    )
+    num_on_team = len(self.agents_of_team[Team.BLUE_TEAM])
 
     for i in range(num_on_team - 1):
         teammate_name = f"teammate_{i}"
@@ -282,7 +285,10 @@ def register_state_elements(team_size):
             (teammate_name, "on_side"), max_bool, min_bool
         )
         agent_obs_normalizer.register(
-            (teammate_name, "tagging_cooldown"), [pyq.config_dict_std["tagging_cooldown"]], [0.0]
+            (teammate_name, "tagging_cooldown"), [self.tagging_cooldown], [0.0]
+        )
+        agent_obs_normalizer.register(
+            (teammate_name, "is_tagged"), max_bool, min_bool
         )
 
     for i in range(num_on_team):
@@ -304,7 +310,10 @@ def register_state_elements(team_size):
             (opponent_name, "on_side"), max_bool, min_bool
         )
         agent_obs_normalizer.register(
-            (opponent_name, "tagging_cooldown"), [pyq.config_dict_std["tagging_cooldown"]], [0.0]
+            (opponent_name, "tagging_cooldown"), [self.tagging_cooldown], [0.0]
+        )
+        agent_obs_normalizer.register(
+            (opponent_name, "is_tagged"), max_bool, min_bool
         )
 
     return agent_obs_normalizer

--- a/pyquaticus/base_policies/base_policies.py
+++ b/pyquaticus/base_policies/base_policies.py
@@ -234,14 +234,14 @@ def CombinedGen(agentid, team, mode, team_size):
     return CombinedPolicy
 
 # Function to create the normalizer for observations
-def register_state_elements(self):
+def register_state_elements(team_size):
     """Initializes the normalizer."""
     agent_obs_normalizer = ObsNormalizer(True)
     max_bearing = [180]
-    max_dist = [np.linalg.norm(self.world_size) + 10]  # add a ten meter buffer
+    max_dist = [np.linalg.norm(pyq.config_dict_std["world_size"]) + 10] # add a ten meter buffer
     min_dist = [0.0]
     max_bool, min_bool = [1.0], [0.0]
-    max_speed, min_speed = [self.max_speed], [0.0]
+    max_speed, min_speed = [pyq.config_dict_std["max_speed"]], [0.0]
     agent_obs_normalizer.register("retrieve_flag_bearing", max_bearing)
     agent_obs_normalizer.register("retrieve_flag_distance", max_dist, min_dist)
     agent_obs_normalizer.register("protect_flag_bearing", max_bearing)
@@ -258,13 +258,11 @@ def register_state_elements(self):
     agent_obs_normalizer.register("has_flag", max_bool, min_bool)
     agent_obs_normalizer.register("on_side", max_bool, min_bool)
     agent_obs_normalizer.register(
-        "tagging_cooldown", [self.tagging_cooldown], [0.0]
+        "tagging_cooldown", [pyq.config_dict_std["tagging_cooldown"]], [0.0]
     )
     agent_obs_normalizer.register("is_tagged", max_bool, min_bool)
-    assert len(self.agents_of_team[Team.BLUE_TEAM]) == len(
-        self.agents_of_team[Team.RED_TEAM]
-    )
-    num_on_team = len(self.agents_of_team[Team.BLUE_TEAM])
+
+    num_on_team = team_size
 
     for i in range(num_on_team - 1):
         teammate_name = f"teammate_{i}"
@@ -285,7 +283,7 @@ def register_state_elements(self):
             (teammate_name, "on_side"), max_bool, min_bool
         )
         agent_obs_normalizer.register(
-            (teammate_name, "tagging_cooldown"), [self.tagging_cooldown], [0.0]
+            (teammate_name, "tagging_cooldown"), [pyq.config_dict_std["tagging_cooldown"]], [0.0]
         )
         agent_obs_normalizer.register(
             (teammate_name, "is_tagged"), max_bool, min_bool
@@ -310,7 +308,7 @@ def register_state_elements(self):
             (opponent_name, "on_side"), max_bool, min_bool
         )
         agent_obs_normalizer.register(
-            (opponent_name, "tagging_cooldown"), [self.tagging_cooldown], [0.0]
+            (opponent_name, "tagging_cooldown"), [pyq.config_dict_std["tagging_cooldown"]], [0.0]
         )
         agent_obs_normalizer.register(
             (opponent_name, "is_tagged"), max_bool, min_bool

--- a/pyquaticus/envs/pyquaticus.py
+++ b/pyquaticus/envs/pyquaticus.py
@@ -1357,6 +1357,9 @@ class PyQuaticusEnv(ParallelEnv):
             agent_obs_normalizer.register(
                 (teammate_name, "tagging_cooldown"), [self.tagging_cooldown], [0.0]
             )
+            agent_obs_normalizer.register(
+                (teammate_name, "is_tagged"), max_bool, min_bool
+            )
 
         for i in range(num_on_team):
             opponent_name = f"opponent_{i}"
@@ -1378,6 +1381,9 @@ class PyQuaticusEnv(ParallelEnv):
             )
             agent_obs_normalizer.register(
                 (opponent_name, "tagging_cooldown"), [self.tagging_cooldown], [0.0]
+            )
+            agent_obs_normalizer.register(
+                (opponent_name, "is_tagged"), max_bool, min_bool
             )
 
         return agent_obs_normalizer
@@ -1418,11 +1424,13 @@ class PyQuaticusEnv(ParallelEnv):
                 Has flag status (boolean)
                 On their side status (boolean)
                 Tagging cooldown (seconds)
+                Is tagged (boolean)
         Note 1 : the angles are 0 when the agent is pointed directly at the object
                  and increase in the clockwise direction
         Note 2 : the wall distances can be negative when the agent is out of bounds
         Note 3 : the boolean args Tag/Flag status are -1 false and +1 true
         Developer Note 1: changes here should be reflected in _register_state_elements.
+        Developer Note 2: changes here should be reflected in register_state_elements in base_policies.py
         """
         agent = self.players[agent_id]
         obs_dict = OrderedDict()
@@ -1524,6 +1532,7 @@ class PyQuaticusEnv(ParallelEnv):
                 obs[(entry_name, "has_flag")] = dif_agent.has_flag
                 obs[(entry_name, "on_side")] = dif_agent.on_own_side
                 obs[(entry_name, "tagging_cooldown")] = dif_agent.tagging_cooldown
+                obs[(entry_name, "is_tagged")] = self.state["agent_tagged"][dif_agent.id]
 
         obs_dict[agent.id] = obs
         if self.normalize:

--- a/pyquaticus/envs/pyquaticus.py
+++ b/pyquaticus/envs/pyquaticus.py
@@ -606,6 +606,7 @@ class PyQuaticusEnv(ParallelEnv):
             if (
                 ag_dis_2_flag < self.flag_keepout
                 and not self.state["flag_taken"][int(player.team)]
+                and config_dict_std["keepout_bounce"] > 0
             ):
                 self.flag_collision_bool[player.id] = True
 

--- a/pyquaticus/envs/pyquaticus.py
+++ b/pyquaticus/envs/pyquaticus.py
@@ -626,6 +626,7 @@ class PyQuaticusEnv(ParallelEnv):
                     # print("here")
                     player.reset()
                 else:
+                    self.state["agent_tagged"][player.id] = 1
                     player.rotate()
                 continue
             else:

--- a/pyquaticus/envs/pyquaticus.py
+++ b/pyquaticus/envs/pyquaticus.py
@@ -1001,6 +1001,9 @@ class PyQuaticusEnv(ParallelEnv):
             self.params[agent.id]["opponent_flag_pickup"] = self.blue_team_flag_pickup
             self.params[agent.id]["opponent_flag_capture"] = self.blue_team_flag_capture
             # Elements
+            self.params[agent.id]["team_flag_home"] = self.get_distance_between_2_points(
+                    agent.pos, self.state["flag_home"][1]
+                )
             self.params[agent.id]["team_flag_bearing"] = obs["protect_flag_bearing"]
             self.params[agent.id]["team_flag_distance"] = obs["protect_flag_distance"]
             self.params[agent.id]["opponent_flag_bearing"] = obs[
@@ -1018,6 +1021,9 @@ class PyQuaticusEnv(ParallelEnv):
             self.params[agent.id]["opponent_flag_pickup"] = self.red_team_flag_pickup
             self.params[agent.id]["opponent_flag_capture"] = self.red_team_flag_capture
             # Elements
+            self.params[agent.id]["team_flag_home"] = self.get_distance_between_2_points(
+                    agent.pos, self.state["flag_home"][0]
+                )
             self.params[agent.id]["team_flag_bearing"] = obs["protect_flag_bearing"]
             self.params[agent.id]["team_flag_distance"] = obs["protect_flag_distance"]
             self.params[agent.id]["opponent_flag_bearing"] = obs[

--- a/pyquaticus/envs/pyquaticus.py
+++ b/pyquaticus/envs/pyquaticus.py
@@ -1329,6 +1329,7 @@ class PyQuaticusEnv(ParallelEnv):
         agent_obs_normalizer.register(
             "tagging_cooldown", [self.tagging_cooldown], [0.0]
         )
+        agent_obs_normalizer.register("is_tagged", max_bool, min_bool)
         assert len(self.agents_of_team[Team.BLUE_TEAM]) == len(
             self.agents_of_team[Team.RED_TEAM]
         )
@@ -1406,6 +1407,7 @@ class PyQuaticusEnv(ParallelEnv):
             Own speed (meters per second)
             Own flag status (boolean)
             On side (boolean)
+            Is tagged (boolean)
             Tagging cooldown (seconds) time elapsed since last tag (at max when you can tag again)
             For each other agent (teammates first) [Consider sorting teammates and opponents by distance or flag status]
                 Bearing from you (clockwise degrees)
@@ -1419,7 +1421,7 @@ class PyQuaticusEnv(ParallelEnv):
                  and increase in the clockwise direction
         Note 2 : the wall distances can be negative when the agent is out of bounds
         Note 3 : the boolean args Tag/Flag status are -1 false and +1 true
-        Developer Note 1: changes here should be reflected in _register_state_elemnts.
+        Developer Note 1: changes here should be reflected in _register_state_elements.
         """
         agent = self.players[agent_id]
         obs_dict = OrderedDict()
@@ -1490,6 +1492,9 @@ class PyQuaticusEnv(ParallelEnv):
         # On side
         obs["on_side"] = agent.on_own_side
         obs["tagging_cooldown"] = agent.tagging_cooldown
+
+        #Is tagged
+        obs["is_tagged"] = self.state["agent_tagged"][agent.id]
 
         # Relative observations to other agents
         # teammates first

--- a/pyquaticus/envs/pyquaticus.py
+++ b/pyquaticus/envs/pyquaticus.py
@@ -245,7 +245,7 @@ class Player:
         self.has_flag = False
         self.on_sides = True
 
-    def rotate(self):
+    def rotate(self, angle=180):
         """Method to rotate the player 180"""
         self.prev_pos = self.pos
         self.speed = 0
@@ -267,7 +267,7 @@ class Player:
             self.pos[1] -= 1
         
         # Rotate 180 degrees
-        self.heading = angle180(self.heading + 180)
+        self.heading = angle180(self.heading + angle)
 
             
             
@@ -534,7 +534,7 @@ class PyQuaticusEnv(ParallelEnv):
         self._check_pickup_flags()
         self._check_agent_captures()
         self._check_flag_captures()
-        if config_dict_std["teleport_on_tag"] == False:
+        if not config_dict_std["teleport_on_tag"]:
             self._check_untag()
         self._set_dones()
 
@@ -622,8 +622,7 @@ class PyQuaticusEnv(ParallelEnv):
                     self.flags[int(not int(player.team))].reset()
                     self.state["flag_taken"][int(not int(player.team))] = 0
                 self.state["agent_oob"][player.id] = 1
-                if (config_dict_std["teleport_on_tag"]):
-                    # print("here")
+                if config_dict_std["teleport_on_tag"]:
                     player.reset()
                 else:
                     self.state["agent_tagged"][player.id] = 1
@@ -763,7 +762,7 @@ class PyQuaticusEnv(ParallelEnv):
                             self.state["agent_captures"][player.id] = other_player.id
                             # If we get here, then `player` tagged `other_player` and we need to reset `other_player`
                             # Only if config["teleport_on_capture"] == True
-                            if config_dict_std["teleport_on_tag"] == True:
+                            if config_dict_std["teleport_on_tag"]:
                                 buffer_sign = (
                                     1.0
                                     if self.flags[o_team].home[0] < self.scrimmage

--- a/pyquaticus/envs/pyquaticus.py
+++ b/pyquaticus/envs/pyquaticus.py
@@ -245,6 +245,34 @@ class Player:
         self.has_flag = False
         self.on_sides = True
 
+    def rotate(self):
+        """Method to rotate the player 180"""
+        self.prev_pos = self.pos
+        self.speed = 0
+        self.thrust = 0
+        self.has_flag = False
+       
+        # Need to get which wall the agent bumped into
+        x_pos = self.pos[0]
+        y_pos = self.pos[1]
+
+        if (x_pos < self.r):
+            self.pos[0] += 1
+        elif(config_dict_std["world_size"][0] - self.r < x_pos):
+            self.pos[0] -= 1
+        
+        if (y_pos < self.r):
+            self.pos[1] += 1
+        elif(config_dict_std["world_size"][1] - self.r < y_pos):
+            self.pos[1] -= 1
+        
+        # Rotate 180 degrees
+        self.heading = angle180(self.heading + 180)
+
+            
+            
+
+
 
 @dataclass
 class Flag:
@@ -594,7 +622,11 @@ class PyQuaticusEnv(ParallelEnv):
                     self.flags[int(not int(player.team))].reset()
                     self.state["flag_taken"][int(not int(player.team))] = 0
                 self.state["agent_oob"][player.id] = 1
-                player.reset()
+                if (config_dict_std["teleport_on_tag"]):
+                    # print("here")
+                    player.reset()
+                else:
+                    player.rotate()
                 continue
             else:
                 self.state["agent_oob"][player.id] = 0

--- a/pyquaticus/envs/pyquaticus.py
+++ b/pyquaticus/envs/pyquaticus.py
@@ -725,9 +725,9 @@ class PyQuaticusEnv(ParallelEnv):
         """Untags the player if they return to their own flag."""
         for player in self.players:
             team = int(player.team)
-            flag_pos = self.flags[team].pos
+            flag_home = self.flags[team].home
             distance_to_flag = self.get_distance_between_2_points(
-                player.pos, flag_pos
+                player.pos, flag_home
             )
             if distance_to_flag < self.catch_radius and self.state["agent_tagged"][player.id]:
                 self.state["agent_tagged"][player.id] = 0
@@ -740,10 +740,10 @@ class PyQuaticusEnv(ParallelEnv):
 
         self.state["agent_captures"] = [None] * self.num_agents
         for player in self.players:
-            # Only continue logic check if player tagged someone if it's on its own side.
+            # Only continue logic check if player tagged someone if it's on its own side and is untagged.
             if player.on_own_side and (
                 player.tagging_cooldown == self.tagging_cooldown
-            ):
+            ) and not self.state["agent_tagged"][player.id]:
                 for other_player in self.players:
                     o_team = int(other_player.team)
                     # Only do the rest if the other player is NOT on sides and they are not on the same team.

--- a/pyquaticus/utils/rewards.py
+++ b/pyquaticus/utils/rewards.py
@@ -46,6 +46,7 @@ params{
     "team_flag_capture": bool,   # Indicates if team captures flag
     "opponent_flag_pickup": bool, # Indicates if opponent grabs flag 
     "opponent_flag_capture": bool, #Indicates if opponent grabs flag
+    "team_flag_home": float, #Agents distance to flag home (to untag)
     "team_flag_bearing": float, # Agents bearing to team flag
     "team_flag_distance": float, # Agents distance to team flag
     "opponent_flag_bearing": float, # Agents bearing to opponents flag
@@ -121,6 +122,7 @@ def sparse(self, params, prev_params):
     # Penalize agent if it went out of bounds (Hit border wall)
     if params["agent_oob"][params["agent_id"]] == 1:
         reward -= 100
+
     return reward
 
 


### PR DESCRIPTION
This branch adds the option to remove the ability to teleport so on tag and out of bounds, the agent will need to return home itself. You can toggle the option in the config_dict_std at the top of pyquaticus.py 

I was trying to update the base policies but it seems that the observations space doesn't return which agents are tagged. I was about to add that but wasn't sure if that would align with the MOOS observation space so let me know what I should do there.

Also, another feature I was thinking would be helpful would be in the pygame render to change the color of the agent when they are tagged, but I am not too experienced with pygame so let me know if you thinks that a good idea.