### PR TITLE
Align pyquaticus flag observations with pyquaticus bridge

### DIFF
--- a/docker/gym-aquaticus/gym_aquaticus/envs/pyquaticus_team_env_bridge.py
+++ b/docker/gym-aquaticus/gym_aquaticus/envs/pyquaticus_team_env_bridge.py
@@ -112,25 +112,25 @@ class PyquaticusBridge(AquaticusTeamEnv):
         pnt, has_flag, on_side = agent_states[agent_name]
         np_pos = np.array([pnt.x, pnt.y], dtype=np.float32)
 
-        retrieve_flag_loc, protect_flag_loc = self.get_team_goal_defend(own_team)
+        opponent_home_loc, own_home_loc = self.get_team_goal_defend(own_team)
 
         obs = OrderedDict()
         # Goal flag
-        retrieve_flag_dist, retrieve_flag_bearing = mag_heading_to(
-            np_pos, retrieve_flag_loc, pnt.heading
+        opponent_home_dist, opponent_home_bearing = mag_heading_to(
+            np_pos, opponent_home_loc, pnt.heading
         )
         # Defend flag
-        protect_flag_dist, protect_flag_bearing = mag_heading_to(
-            np_pos, protect_flag_loc, pnt.heading
+        own_home_dist, own_home_bearing = mag_heading_to(
+            np_pos, own_home_loc, pnt.heading
         )
 
         # TODO: consider swapping goal location once flag is retrieved
         #       especially if we're bringing the flag all the way back
 
-        obs["retrieve_flag_bearing"] = retrieve_flag_bearing
-        obs["retrieve_flag_distance"] = retrieve_flag_dist
-        obs["protect_flag_bearing"] = protect_flag_bearing
-        obs["protect_flag_distance"] = protect_flag_dist
+        obs["opponent_home_bearing"] = opponent_home_bearing
+        obs["opponent_home_distance"] = opponent_home_dist
+        obs["own_home_bearing"] = own_home_bearing
+        obs["own_home_distance"] = own_home_dist
 
         # Walls
         wall_0_closest_point = closest_point_on_line(
@@ -239,10 +239,10 @@ class PyquaticusBridge(AquaticusTeamEnv):
         min_speed, max_speed = self._moos_config.speed_bounds
         max_speed += 2 # add some padding to the max speed
         min_speed, max_speed = [min_speed], [max_speed]
-        agent_obs_normalizer.register("retrieve_flag_bearing", max_bearing)
-        agent_obs_normalizer.register("retrieve_flag_distance", max_dist, min_dist)
-        agent_obs_normalizer.register("protect_flag_bearing", max_bearing)
-        agent_obs_normalizer.register("protect_flag_distance", max_dist, min_dist)
+        agent_obs_normalizer.register("opponent_home_bearing", max_bearing)
+        agent_obs_normalizer.register("opponent_home_distance", max_dist, min_dist)
+        agent_obs_normalizer.register("own_home_bearing", max_bearing)
+        agent_obs_normalizer.register("own_home_distance", max_dist, min_dist)
         agent_obs_normalizer.register("wall_0_bearing", max_bearing)
         agent_obs_normalizer.register("wall_0_distance", max_dist, min_dist)
         agent_obs_normalizer.register("wall_1_bearing", max_bearing)

--- a/pyquaticus/base_policies/base.py
+++ b/pyquaticus/base_policies/base.py
@@ -93,16 +93,16 @@ class BaseAgentPolicy:
 
         # Calculate the rectangular coordinates for the flags location relative to the agent.
         self.my_flag_loc = (
-            my_obs["protect_flag_distance"]
-            * np.cos(np.deg2rad(my_obs["protect_flag_bearing"])),
-            my_obs["protect_flag_distance"]
-            * np.sin(np.deg2rad(my_obs["protect_flag_bearing"])),
+            my_obs["own_home_distance"]
+            * np.cos(np.deg2rad(my_obs["own_home_bearing"])),
+            my_obs["own_home_distance"]
+            * np.sin(np.deg2rad(my_obs["own_home_bearing"])),
         )
         self.opp_flag_loc = (
-            my_obs["retrieve_flag_distance"]
-            * np.cos(np.deg2rad(my_obs["retrieve_flag_bearing"])),
-            my_obs["retrieve_flag_distance"]
-            * np.sin(np.deg2rad(my_obs["retrieve_flag_bearing"])),
+            my_obs["opponent_home_distance"]
+            * np.cos(np.deg2rad(my_obs["opponent_home_bearing"])),
+            my_obs["opponent_home_distance"]
+            * np.sin(np.deg2rad(my_obs["opponent_home_bearing"])),
         )
 
         self.home = (

--- a/pyquaticus/base_policies/base_attack.py
+++ b/pyquaticus/base_policies/base_attack.py
@@ -76,10 +76,10 @@ class BaseAttacker(BaseAgentPolicy):
         if self.mode == "easy":
             # If I or someone on my team has the flag, go back home
             if self.has_flag or self.my_team_has_flag:
-                goal_vect = self.bearing_to_vec(my_obs["protect_flag_bearing"])
+                goal_vect = self.bearing_to_vec(my_obs["own_home_bearing"])
             # Otherwise go get the opponents flag
             else:
-                goal_vect = self.bearing_to_vec(my_obs["retrieve_flag_bearing"])
+                goal_vect = self.bearing_to_vec(my_obs["opponent_home_bearing"])
 
             # Convert the vector to a heading, and then pick the best discrete action to perform
             try:
@@ -105,7 +105,7 @@ class BaseAttacker(BaseAgentPolicy):
             if self.has_flag or self.my_team_has_flag:
                 # Weighted to follow goal more than avoiding others
                 goal_vect = np.multiply(
-                    2.00, self.bearing_to_vec(my_obs["protect_flag_bearing"])
+                    2.00, self.bearing_to_vec(my_obs["own_home_bearing"])
                 )
                 avoid_vect = self.get_avoid_vect(self.opp_team_pos)
                 my_action = goal_vect + avoid_vect
@@ -113,7 +113,7 @@ class BaseAttacker(BaseAgentPolicy):
             # Otherwise, go get the other teams flag
             else:
                 goal_vect = np.multiply(
-                    2.00, self.bearing_to_vec(my_obs["retrieve_flag_bearing"])
+                    2.00, self.bearing_to_vec(my_obs["opponent_home_bearing"])
                 )
                 avoid_vect = self.get_avoid_vect(self.opp_team_pos)
                 my_action = goal_vect + avoid_vect
@@ -186,7 +186,7 @@ class BaseAttacker(BaseAgentPolicy):
             # If I or someone on my team has the flag, go back to my side
             if self.has_flag or self.my_team_has_flag:
                 goal_vect = np.multiply(
-                    1.25, self.bearing_to_vec(my_obs["protect_flag_bearing"])
+                    1.25, self.bearing_to_vec(my_obs["own_home_bearing"])
                 )
                 avoid_vect = self.get_avoid_vect(
                     self.opp_team_pos, avoid_threshold=avoid_thresh
@@ -195,7 +195,7 @@ class BaseAttacker(BaseAgentPolicy):
 
             # Otherwise go get the flag
             else:
-                goal_vect = self.bearing_to_vec(my_obs["retrieve_flag_bearing"])
+                goal_vect = self.bearing_to_vec(my_obs["opponent_home_bearing"])
                 avoid_vect = self.get_avoid_vect(
                     self.opp_team_pos, avoid_threshold=avoid_thresh
                 )

--- a/pyquaticus/base_policies/base_combined.py
+++ b/pyquaticus/base_policies/base_combined.py
@@ -188,9 +188,9 @@ class Heuristic_CTF_Agent(BaseAgentPolicy):
             if np.random.random() < 0.5:
                 goal_vec = self.bearing_to_vec(nearest_enemy[1])
             else:
-                own_flag_dist = my_obs["protect_flag_distance"]
+                own_flag_dist = my_obs["own_home_distance"]
                 if own_flag_dist > self.flag_keepout + 2.0:
-                    goal_vec = self.bearing_to_vec(my_obs["protect_flag_bearing"])
+                    goal_vec = self.bearing_to_vec(my_obs["own_home_bearing"])
                 else:
                     span_len = self.scrimmage - self.defensiveness
                     goal_vec = [np.random.random() * span_len, 0]

--- a/pyquaticus/base_policies/base_defend.py
+++ b/pyquaticus/base_policies/base_defend.py
@@ -78,11 +78,11 @@ class BaseDefender(BaseAgentPolicy):
 
         if self.mode == "easy":
             ag_vect = [0, 0]
-            my_flag_vec = self.bearing_to_vec(my_obs["protect_flag_bearing"])
+            my_flag_vec = self.bearing_to_vec(my_obs["own_home_bearing"])
             
            
             # If far away from the flag, move towards it
-            if my_obs["protect_flag_distance"] > (
+            if my_obs["own_home_distance"] > (
                 self.flag_keepout + self.catch_radius + 1.0
             ):
                 ag_vect = my_flag_vec
@@ -103,7 +103,7 @@ class BaseDefender(BaseAgentPolicy):
                 act_index = 10
 
         elif self.mode == "medium":
-            my_flag_vec = self.bearing_to_vec(my_obs["protect_flag_bearing"])
+            my_flag_vec = self.bearing_to_vec(my_obs["own_home_bearing"])
     
             # If the blue team doesn't have the flag, guard it
             if self.opp_team_has_flag:
@@ -111,7 +111,7 @@ class BaseDefender(BaseAgentPolicy):
                 ag_vect = my_flag_vec
 
             else:
-                flag_dist = my_obs["protect_flag_distance"]
+                flag_dist = my_obs["own_home_distance"]
 
                 if flag_dist > (self.flag_keepout + self.catch_radius + 1.0):
                     ag_vect = my_flag_vec
@@ -213,7 +213,7 @@ class BaseDefender(BaseAgentPolicy):
 
                 ag_vect = guide_pt
             else:
-                ag_vect = self.bearing_to_vec(my_obs["protect_flag_bearing"])
+                ag_vect = self.bearing_to_vec(my_obs["own_home_bearing"])
 
             if wall_pos is not None:
                 ag_vect = ag_vect + self.get_avoid_vect(wall_pos)

--- a/pyquaticus/base_policies/base_policies.py
+++ b/pyquaticus/base_policies/base_policies.py
@@ -242,10 +242,10 @@ def register_state_elements(team_size):
     min_dist = [0.0]
     max_bool, min_bool = [1.0], [0.0]
     max_speed, min_speed = [pyq.config_dict_std["max_speed"]], [0.0]
-    agent_obs_normalizer.register("retrieve_flag_bearing", max_bearing)
-    agent_obs_normalizer.register("retrieve_flag_distance", max_dist, min_dist)
-    agent_obs_normalizer.register("protect_flag_bearing", max_bearing)
-    agent_obs_normalizer.register("protect_flag_distance", max_dist, min_dist)
+    agent_obs_normalizer.register("opponent_home_bearing", max_bearing)
+    agent_obs_normalizer.register("opponent_home_distance", max_dist, min_dist)
+    agent_obs_normalizer.register("own_home_bearing", max_bearing)
+    agent_obs_normalizer.register("own_home_distance", max_dist, min_dist)
     agent_obs_normalizer.register("agent_home_distance", max_dist, min_dist)
     agent_obs_normalizer.register("agent_home_bearing", max_bearing)
     agent_obs_normalizer.register("wall_0_bearing", max_bearing)


### PR DESCRIPTION
This PR renames `[retrieve|protect]_flag_*` to `[own|opponent]_home_*`. This is because the MOOS bridge pointed to the flag home rather than the actual flag location, so this aligns the semantics.