### PR TITLE
Fixing base policies to work with new observations

### DIFF
--- a/pyquaticus/base_policies/base.py
+++ b/pyquaticus/base_policies/base.py
@@ -106,10 +106,10 @@ class BaseAgentPolicy:
         )
 
         self.home = (
-            my_obs["agent_home_distance"]
-            * np.cos(np.deg2rad(my_obs["agent_home_bearing"])),
-            my_obs["agent_home_distance"]
-            * np.sin(np.deg2rad(my_obs["agent_home_bearing"])),
+            my_obs["own_home_distance"]
+            * np.cos(np.deg2rad(my_obs["own_home_bearing"])),
+            my_obs["own_home_distance"]
+            * np.sin(np.deg2rad(my_obs["own_home_bearing"])),
         )
 
         # Copy the polar positions of each agent, separated by team and get their tag status

--- a/pyquaticus/base_policies/base_attack.py
+++ b/pyquaticus/base_policies/base_attack.py
@@ -79,7 +79,7 @@ class BaseAttacker(BaseAgentPolicy):
                 goal_vect = self.bearing_to_vec(my_obs["own_home_bearing"])
             # Otherwise go get the opponents flag
             else:
-                goal_vect = self.bearing_to_vec(my_obs["opponent_home_bearing"])
+                goal_vect = self.bearing_to_vec(self.opp_flag_bearing)
 
             # Convert the vector to a heading, and then pick the best discrete action to perform
             try:
@@ -113,7 +113,7 @@ class BaseAttacker(BaseAgentPolicy):
             # Otherwise, go get the other teams flag
             else:
                 goal_vect = np.multiply(
-                    2.00, self.bearing_to_vec(my_obs["opponent_home_bearing"])
+                    2.00, self.bearing_to_vec(self.opp_flag_bearing)
                 )
                 avoid_vect = self.get_avoid_vect(self.opp_team_pos)
                 my_action = goal_vect + avoid_vect
@@ -195,7 +195,7 @@ class BaseAttacker(BaseAgentPolicy):
 
             # Otherwise go get the flag
             else:
-                goal_vect = self.bearing_to_vec(my_obs["opponent_home_bearing"])
+                goal_vect = self.bearing_to_vec(self.opp_flag_bearing)
                 avoid_vect = self.get_avoid_vect(
                     self.opp_team_pos, avoid_threshold=avoid_thresh
                 )

--- a/pyquaticus/base_policies/base_combined.py
+++ b/pyquaticus/base_policies/base_combined.py
@@ -188,9 +188,9 @@ class Heuristic_CTF_Agent(BaseAgentPolicy):
             if np.random.random() < 0.5:
                 goal_vec = self.bearing_to_vec(nearest_enemy[1])
             else:
-                own_flag_dist = my_obs["own_home_distance"]
+                own_flag_dist = self.my_flag_distance
                 if own_flag_dist > self.flag_keepout + 2.0:
-                    goal_vec = self.bearing_to_vec(my_obs["own_home_bearing"])
+                    goal_vec = self.bearing_to_vec(self.my_flag_bearing)
                 else:
                     span_len = self.scrimmage - self.defensiveness
                     goal_vec = [np.random.random() * span_len, 0]

--- a/pyquaticus/base_policies/base_defend.py
+++ b/pyquaticus/base_policies/base_defend.py
@@ -78,11 +78,11 @@ class BaseDefender(BaseAgentPolicy):
 
         if self.mode == "easy":
             ag_vect = [0, 0]
-            my_flag_vec = self.bearing_to_vec(my_obs["own_home_bearing"])
+            my_flag_vec = self.bearing_to_vec(self.my_flag_bearing)
             
            
             # If far away from the flag, move towards it
-            if my_obs["own_home_distance"] > (
+            if self.my_flag_distance > (
                 self.flag_keepout + self.catch_radius + 1.0
             ):
                 ag_vect = my_flag_vec
@@ -103,7 +103,7 @@ class BaseDefender(BaseAgentPolicy):
                 act_index = 10
 
         elif self.mode == "medium":
-            my_flag_vec = self.bearing_to_vec(my_obs["own_home_bearing"])
+            my_flag_vec = self.bearing_to_vec(self.my_flag_bearing)
     
             # If the blue team doesn't have the flag, guard it
             if self.opp_team_has_flag:
@@ -111,7 +111,7 @@ class BaseDefender(BaseAgentPolicy):
                 ag_vect = my_flag_vec
 
             else:
-                flag_dist = my_obs["own_home_distance"]
+                flag_dist = self.my_flag_distance
 
                 if flag_dist > (self.flag_keepout + self.catch_radius + 1.0):
                     ag_vect = my_flag_vec
@@ -213,7 +213,7 @@ class BaseDefender(BaseAgentPolicy):
 
                 ag_vect = guide_pt
             else:
-                ag_vect = self.bearing_to_vec(my_obs["own_home_bearing"])
+                ag_vect = self.bearing_to_vec(self.my_flag_bearing)
 
             if wall_pos is not None:
                 ag_vect = ag_vect + self.get_avoid_vect(wall_pos)

--- a/pyquaticus/envs/pyquaticus.py
+++ b/pyquaticus/envs/pyquaticus.py
@@ -1450,6 +1450,17 @@ class PyQuaticusEnv(PyQuaticusEnvBase):
             flag = self.flags[int(team)]
             teams_players = self.agents_of_team[team]
             color = "blue" if team == Team.BLUE_TEAM else "red"
+
+            # Draw team home region
+            home_center_screen = self.world_to_screen(self.flags[int(team)].home)
+            draw.circle(
+                    self.screen,
+                    (0, 0, 0),
+                    home_center_screen,
+                    self.catch_radius * self.pixel_size,
+                    width=round(self.agent_radius * self.pixel_size / 20),
+                )
+
             if not self.state["flag_taken"][int(team)]:
                 # Flag is not captured, draw normally.
                 flag_pos_screen = self.world_to_screen(flag.pos)
@@ -1464,13 +1475,6 @@ class PyQuaticusEnv(PyQuaticusEnvBase):
                     color,
                     flag_pos_screen,
                     (self.flag_keepout - self.agent_radius) * self.pixel_size,
-                    width=round(self.agent_radius * self.pixel_size / 20),
-                )
-                draw.circle(
-                    self.screen,
-                    (0, 0, 0),
-                    flag_pos_screen,
-                    self.catch_radius * self.pixel_size,
                     width=round(self.agent_radius * self.pixel_size / 20),
                 )
             else:

--- a/pyquaticus/structs.py
+++ b/pyquaticus/structs.py
@@ -195,7 +195,7 @@ class RenderingPlayer(Player):
         self.pygame_agent = self.pygame_agent_base.copy()
 
         # render_is_tagged
-        if self.is_tagged :
+        if self.is_tagged:
             draw.circle(
                 self.pygame_agent,
                 (0, 255, 0),


### PR DESCRIPTION
- Cause of original issue: `my_obs["own_home_distance"]`, `my_obs["own_home_bearing"]`, `my_obs["opponent_home_distance"]`, `my_obs["opponent_home_bearing"]` are static and refer to the agent's relative home distance/bearing where the flag is (sometimes), but do not change when the flag is picked up. These variables were being used to track distance/bearing of flag.
- Went through base policies and checked to see where these variables were being used to get the position/bearing of the flag and replaced them with the actual position/ bearing of the flag (now saved as `self.my_flag_distance`, `self.my_flag_bearing`, `self.opp_flag_distance`, and `self.opp_flag_bearing` in [base.py](https://github.com/mit-ll-trusted-autonomy/pyquaticus/blob/align_base_p/pyquaticus/base_policies/base.py)
- Small visualization change: team home region no longer disappears when flag is picked up
