### PR TITLE
Pass obs normalizer to defend policy

### DIFF
--- a/pyquaticus/base_policies/base.py
+++ b/pyquaticus/base_policies/base.py
@@ -34,6 +34,13 @@ class BaseAgentPolicy:
 
     def __init__(self, agent_id: int, team: Team, suppress_numpy_warnings=True):
         self.id = agent_id
+        if isinstance(team, str):
+            if team == 'red':
+                team = Team.RED_TEAM
+            elif team == 'blue':
+                team = Team.BLUE_TEAM
+            else:
+                raise ValueError(f"Got unknown team: {team}")
         self.team = team
         self.speed = 0.0
         self.has_flag = False

--- a/rl_test/train_against_easy.py
+++ b/rl_test/train_against_easy.py
@@ -88,9 +88,9 @@ if __name__ == '__main__':
             # change this to agent-1-policy to train both agents at once
             return "easy-defend-policy"
     
-    env.close()
     policies = {'agent-0-policy':(None, obs_space, act_space, {}), 
-                'easy-defend-policy': (DefendGen(1, 'red', 'easy', 1), obs_space, act_space, {})}
+                'easy-defend-policy': (DefendGen(1, 'red', 'easy', 1, env.par_env.agent_obs_normalizer), obs_space, act_space, {})}
+    env.close()
     ppo_config = PPOConfig().environment(env='pyquaticus').rollouts(num_rollout_workers=5).resources(num_cpus_per_worker=2, num_gpus=int(os.environ.get("RLLIB_NUM_GPUS", "0")))
     ppo_config.multi_agent(policies=policies, policy_mapping_fn=policy_mapping_fn, policies_to_train=["agent-0-policy"],)
     algo = ppo_config.build()

--- a/rl_test/train_against_easy.py
+++ b/rl_test/train_against_easy.py
@@ -89,7 +89,7 @@ if __name__ == '__main__':
             return "easy-defend-policy"
     
     policies = {'agent-0-policy':(None, obs_space, act_space, {}), 
-                'easy-defend-policy': (DefendGen(1, 'red', 'easy', 1, env.par_env.agent_obs_normalizer), obs_space, act_space, {})}
+                'easy-defend-policy': (DefendGen(1, Team.RED_TEAM, 'easy', 1, env.par_env.agent_obs_normalizer), obs_space, act_space, {})}
     env.close()
     ppo_config = PPOConfig().environment(env='pyquaticus').rollouts(num_rollout_workers=5).resources(num_cpus_per_worker=2, num_gpus=int(os.environ.get("RLLIB_NUM_GPUS", "0")))
     ppo_config.multi_agent(policies=policies, policy_mapping_fn=policy_mapping_fn, policies_to_train=["agent-0-policy"],)


### PR DESCRIPTION
Update the `train_against_easy.py` script to pass the observation normalizer to the `DefendGen` function correctly.