### PR TITLE
Fixing tag cooldown bug to prevent double tag

### DIFF
--- a/pyquaticus/envs/pyquaticus.py
+++ b/pyquaticus/envs/pyquaticus.py
@@ -840,6 +840,9 @@ class PyQuaticusEnv(PyQuaticusEnvBase):
                             # Set players tagging cooldown
                             player.tagging_cooldown = 0.0
 
+                            # Break loop (should not be allowed to tag again until next timestep)
+                            break
+
     def _check_flag_captures(self):
         """Updates states if a player captured a flag."""
         for player in self.players.values():


### PR DESCRIPTION
Previously, when an agent goes from tagged to untagged and is within tagging range to more than 1 enemy in the same timestep, both enemies would be tagged. This patch fixes that but does not allow for any prioritization of which agent should be tagged if both become taggable at the same instant. This is due to the nature of a for loop being used to check for tags in `_check_agent_captures` (would have to loop through all agents and then make that decision). Looking for input on if small fix is good enough or if a full fix (prioritize tag for agent with flag and then closest agent) should be implemented.