### PR TITLE
Fixing base_defend to not chase a tagged agent

### DIFF
--- a/pyquaticus/base_policies/base.py
+++ b/pyquaticus/base_policies/base.py
@@ -82,6 +82,7 @@ class BaseAgentPolicy:
 
         """
         self.opp_team_pos = []
+        self.opp_team_pos_dict = {} #for labeling by agent_id
         self.my_team_pos = []
         self.opp_team_tag = []
         self.my_team_tag = []
@@ -131,6 +132,9 @@ class BaseAgentPolicy:
                 if k[0].find("opponent_") != -1 and k[0] not in opp_team_ids:
                     opp_team_ids.add(k[0])
                     self.opp_team_pos.append(
+                        (my_obs[(k[0], "distance")], my_obs[(k[0], "bearing")])
+                    )
+                    self.opp_team_pos_dict[k[0]] = (
                         (my_obs[(k[0], "distance")], my_obs[(k[0], "bearing")])
                     )
                     self.opp_team_has_flag = (

--- a/pyquaticus/base_policies/base_attack.py
+++ b/pyquaticus/base_policies/base_attack.py
@@ -101,9 +101,6 @@ class BaseAttacker(BaseAgentPolicy):
                 act_index = 12
 
         elif self.mode=="competition_nothing":
-            #If tagged return to untag
-            if self.is_tagged:
-                ag_vect = self.bearing_to_vec(my_obs["own_home_bearing"])
             act_index = -1
 
         elif self.mode=="competition_easy":

--- a/pyquaticus/base_policies/base_defend.py
+++ b/pyquaticus/base_policies/base_defend.py
@@ -104,17 +104,12 @@ class BaseDefender(BaseAgentPolicy):
                 act_index = 10
         
         elif self.mode=="competition_nothing":
-            #If tagged return to untag
-            if self.is_tagged:
-                ag_vect = self.bearing_to_vec(my_obs["own_home_bearing"])
-
             act_index = -1
+
         elif self.mode=="competition_easy":
             coords = [self.my_flag_loc]
-            #If tagged return to untagS
             ag_vect = -1
             if self.is_tagged:
-                ag_vect = self.bearing_to_vec(my_obs["own_home_bearing"])
                 self.competition_easy_1 = [135, 115]
             else:
                 if self.team == Team.RED_TEAM:
@@ -241,12 +236,12 @@ class BaseDefender(BaseAgentPolicy):
 
             ag_vect = [0, 0]
             defense_perim = 5 * self.flag_keepout
-            # Get nearest enemy:
+            # Get nearest untagged enemy:
             min_enemy_distance = 1000.00
-            for enem in self.opp_team_pos:
-                if enem[0] < min_enemy_distance:
-                    min_enemy_distance = enem[0]
-                    enemy_loc = self.rb_to_rect(enem)
+            for enem, pos in self.opp_team_pos_dict.items():
+                if pos[0] < min_enemy_distance and not my_obs[(enem, "is_tagged")]:
+                    min_enemy_distance = pos[0]
+                    enemy_loc = self.rb_to_rect(pos)
 
             if not self.opp_team_has_flag:
                 defend_pt = self.closest_point_on_line(


### PR DESCRIPTION
- Base_defend `"hard"` mode no longer chases tagged agents
- Removing drive to home from base_defend modes `"competition_nothing"` and `"competition_nothing"` (not necessary because drive to home in built into pyquaticus environment now)