### PR TITLE
Flag drop fix

### DIFF
--- a/pyquaticus/envs/pyquaticus.py
+++ b/pyquaticus/envs/pyquaticus.py
@@ -687,6 +687,10 @@ class PyQuaticusEnv(PyQuaticusEnvBase):
                     # If they have a flag, return the flag to it's home area
                     self.flags[int(not int(player.team))].reset()
                     self.state["flag_taken"][int(not int(player.team))] = 0
+                    if player.team == Team.RED_TEAM:
+                        self.red_team_flag_pickup = False
+                    else:
+                        self.blue_team_flag_pickup = False
                 self.state["agent_oob"][player.id] = 1
                 if config_dict_std["teleport_on_tag"]:
                     player.reset()


### PR DESCRIPTION
This is a bug that may have been affecting people's reward functions. It pertains to the `"team_flag_pickup"` param which is set according to `self.blue_team_flag_pickup` or `self.red_team_flag_pickup`. When agents that have picked up the flag run into a wall, they drop the flag but `self.<color>_team_flag_pickup` is never set back to `False`. As far as I can tell this issue does not cause other problems because `self.<color>_team_flag_pickup` is not used to set anything else in the environment.