### PR TITLE
Added Obstacles to environment

### DIFF
--- a/pyquaticus/config.py
+++ b/pyquaticus/config.py
@@ -54,6 +54,13 @@ config_dict_std = {
     "teleport_on_tag": False, # Option for the agent when tagged, either out of bounds or by opponent, to teleport home or not
     "tag_on_wall_collision": False, # Option for setting the agent ot a tagged state upon wall collsion
     "render_field_points": False, #Debugging lets you see where the field points are on the field
+    "obstacles": None, # Optional dictionary of obstacles in the enviornment
+    # Notes: obstacles are specified via dictionary. Keys are the obstacle type ("circle" or "polygon"). 
+    # Values are the parameters for the obstacle. 
+    # Note: For circles, it should be a list of tuples: (radius, (center_x, center_y)) all in meters
+    # Note: For polygons, it should be a list of tuples: ((x1, y1), (x2, y2), (x3, y3), ..., (xn, yn)) all in meters
+    # Note for polygons, there is an implied edge between (xn, yn) and (x1, y1), to complete the polygon.
+
 }
 #Build Point Field - Taken from Moos-IvP-Aquaticus Michael Benjamin
 #=================================================================

--- a/pyquaticus/envs/pyquaticus.py
+++ b/pyquaticus/envs/pyquaticus.py
@@ -765,16 +765,11 @@ class PyQuaticusEnv(PyQuaticusEnvBase):
             # to the next agent.
             player_hit_obstacle = False
             for obstacle in self.obstacles:
-                print(f"Checking obstacle: {obstacle}; Player pos: ({pos_x}, {pos_y})")
+                print(f"Checking obstacle: {obstacle}; Player pos: ({pos_x}, {pos_y}); player heading: {new_heading}")
                 collision = obstacle.detect_collision((pos_x, pos_y), radius = self.agent_radius)
-                print(f"Player {player.id} collided with obstacle? {collision}")
-                print(f"collision is True ? {collision is True} // collision == True ? {collision == True}")
                 if collision is True:
                     player_hit_obstacle = True
-                    print(f"Set player hit obstacle")
                     break
-                else:
-                    print(f"player {player.id} didn't collide")
             if player_hit_obstacle is True or not (
                 (self.agent_radius <= pos_x <= self.world_size[0] - self.agent_radius)
                 and (
@@ -801,7 +796,7 @@ class PyQuaticusEnv(PyQuaticusEnvBase):
                     if self.tag_on_wall_collision:
                         self.state["agent_tagged"][player.id] = 1
                         player.is_tagged = True
-                    player.rotate()
+                    player.rotate(copy.deepcopy(player.prev_pos))
                 continue
             else:
                 self.state["agent_oob"][player.id] = 0

--- a/pyquaticus/envs/pyquaticus.py
+++ b/pyquaticus/envs/pyquaticus.py
@@ -765,7 +765,6 @@ class PyQuaticusEnv(PyQuaticusEnvBase):
             # to the next agent.
             player_hit_obstacle = False
             for obstacle in self.obstacles:
-                print(f"Checking obstacle: {obstacle}; Player pos: ({pos_x}, {pos_y}); player heading: {new_heading}")
                 collision = obstacle.detect_collision((pos_x, pos_y), radius = self.agent_radius)
                 if collision is True:
                     player_hit_obstacle = True
@@ -776,7 +775,6 @@ class PyQuaticusEnv(PyQuaticusEnvBase):
                     self.agent_radius <= pos_y <= self.world_size[1] - self.agent_radius
                 )
             ):
-                print(f"Resetting player {player.id}")
                 if player.team == Team.RED_TEAM:
                     self.game_score['blue_tags'] += 1
                 else:

--- a/pyquaticus/structs.py
+++ b/pyquaticus/structs.py
@@ -169,7 +169,7 @@ class RenderingPlayer(Player):
         self.has_flag = False
         self.on_own_side = True
 
-    def rotate(self, angle=180):
+    def rotate(self, prev_pos, angle=180):
         """Method to rotate the player 180"""
         self.prev_pos = self.pos
         self.speed = 0
@@ -178,37 +178,8 @@ class RenderingPlayer(Player):
         # Rotate 180 degrees
         self.heading = angle180(self.heading + angle)
        
-        # Need to get which wall the agent bumped into
-        x_pos = self.pos[0]
-        y_pos = self.pos[1]
-
-        if (x_pos < self.r):
-            self.pos[0] += 1
-        elif(self.config_dict["world_size"][0] - self.r < x_pos):
-            self.pos[0] -= 1
-        else:
-            if 0 <= self.heading < 90:
-                self.pos[0] += 1
-            elif 90 <= self.heading < 180:
-                self.pos[0] += 1
-            elif -180 <= self.heading < -90:
-                self.pos[0] -= 1
-            else:
-                self.pos[0] -= 1
-        
-        if (y_pos < self.r):
-            self.pos[1] += 1
-        elif(self.config_dict["world_size"][1] - self.r < y_pos):
-            self.pos[1] -= 1
-        else:
-            if 0 <= self.heading < 90:
-                self.pos[1] += 1
-            elif 90 <= self.heading < 180:
-                self.pos[1] -= 1
-            elif -180 <= self.heading < -90:
-                self.pos[1] -= 1
-            else:
-                self.pos[1] += 1
+        self.pos[0] = prev_pos[0]
+        self.pos[1] = prev_pos[1]
         
         
 

--- a/test/arrowkeys_test.py
+++ b/test/arrowkeys_test.py
@@ -141,9 +141,14 @@ def main():
         "circle": [(4, (6, 5))],
         "polygon": [((70, 10), (85, 21), (83, 51), (72, 35))]
     }
+    config["sim_speedup_factor"] = 8
+    # config["normalize"] = False
     
     #PyQuaticusEnv is a Parallel Petting Zoo Environment
-    env = pyquaticus_v0.PyQuaticusEnv(render_mode='human', team_size=1, config_dict=config)
+    try:
+        env = pyquaticus_v0.PyQuaticusEnv(render_mode='human', team_size=1, config_dict=config)
+    except Warning as err:
+        ...
     red_policy = args.red_policy
 
     kt = KeyTest(env, red_policy)

--- a/test/arrowkeys_test.py
+++ b/test/arrowkeys_test.py
@@ -28,7 +28,8 @@ from pygame import KEYDOWN, QUIT, K_ESCAPE, K_SPACE, K_LEFT, K_UP, K_RIGHT, K_a,
 import sys
 import time
 from pyquaticus.envs.pyquaticus import Team
-import pyquaticus
+import pyquaticus.config
+import copy
 from pyquaticus import pyquaticus_v0
 import pyquaticus.utils.rewards as reward
 
@@ -134,9 +135,15 @@ def main():
     reward_config = {0:None, 1:None}
     #Alternative
     #reward_config = {0:reward.sparse, 1:reward.sparse}
+
+    config = copy.deepcopy(pyquaticus.config.config_dict_std)
+    config["obstacles"] = {
+        "circle": [(4, (6, 5))],
+        "polygon": [((70, 10), (85, 21), (83, 51), (72, 35))]
+    }
     
     #PyQuaticusEnv is a Parallel Petting Zoo Environment
-    env = pyquaticus_v0.PyQuaticusEnv(render_mode='human', team_size=1)
+    env = pyquaticus_v0.PyQuaticusEnv(render_mode='human', team_size=1, config_dict=config)
     red_policy = args.red_policy
 
     kt = KeyTest(env, red_policy)


### PR DESCRIPTION
Closes #51 
Added two kinds of obstacles to the environment:
* Circle Obstacles: Defined with a radius and a center X/Y
* Polygon Obstacles: Defined with a list of X/Y vertices. The order of the vertices describes the shape, the last vertex and the first vertex are implied to be connected. There is no limit on the number of vertices that can be specified so complex shapes can be made.

Agents interact with the obstacles the same way they interact with the environment walls. Colliding with them triggers the same out-of-bounds logic, so they will either bounce off the wall when that is set, or move back to their starting area. Agents have the distance and bearing to the closest point on the obstacle in their observation.

Obstacles can be created by passing parameters to the environment via the configuration dictionary. The configuration dictionary has a new `obstacles` key, which is a dictionary that should contain a list of tuples describing each obstacle to be added:

```
config["obstacles"] = {
        "circle": [(4, (6, 5))],
        "polygon": [((70, 10), (85, 21), (83, 51), (72, 35))]
    }
```