### PR TITLE
Heron Dynamics and PID Fix

### DIFF
--- a/pyquaticus/dynamics/dynamics.py
+++ b/pyquaticus/dynamics/dynamics.py
@@ -235,7 +235,14 @@ class BaseUSV(Dynamics):
             -speed PID gains
             -heading (yaw) PID gains
 
-        (2) https://oceanai.mit.edu/ivpman/pmwiki/pmwiki.php?n=IvPTools.USimMarine
+        (2) https://oceanai.mit.edu/svn/moos-ivp-aro/trunk/ivp/src/dep_uSimMarine/USM_Model.cpp
+            -turn_rate
+            -max_acc
+                *if 0, no limit on acceleration
+            -max_decc
+                *if 0, no limit on decceleration
+
+        (3) https://oceanai.mit.edu/ivpman/pmwiki/pmwiki.php?n=IvPTools.USimMarine
             -max_speed
                 *max(thrust_map[1])
             -speed_factor
@@ -244,26 +251,22 @@ class BaseUSV(Dynamics):
             -thrust_map
                 *see section 8.5 for default thrust_map
             -turn_loss
-            -turn_rate
-            -max_acc
-            -max_dec
             -rotate_speed  
     """
     def __init__(
         self,
         max_speed:float = 5.0,  # meters / s
-        speed_factor:float = 0.0,  # [0,inf) scalar correlation between thrust and speed (default is 20)
+        speed_factor:float = 0,  # [0,inf) scalar correlation between thrust and speed
         thrust_map:np.ndarray = np.array(  # piecewise linear mapping from desired_thrust to speed
-            [[-100, 0, 100],
-             [   0, 0, 5.0]]
+            [[-100, 0, 100],[0, 0, 5]]
         ),
         max_thrust:float = 100,  # limit on vehicle thrust
         max_rudder:float = 100,  # limit on vehicle rudder actuation
         turn_loss:float = 0.85,  # [0, 1] affecting speed lost during a turn
         turn_rate:float = 70,  # [0, 100] affecting vehicle turn radius, e.g., 0 is an infinite turn radius
-        max_acc:float = 0.5,  # [0, inf) meters / s**2
+        max_acc:float = 0,  # [0, inf) meters / s**2
         max_dec:float = 0.5,  # [0, inf) meters / s**2
-        rotate_speed:float = 0.0,  # deg/sec (attempt at a thruster bias to account for different thruster capabilities on hardware)
+        rotate_speed:float = 0,  # deg/sec (attempt at a thruster bias to account for different thruster capabilities on hardware)
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -287,6 +290,7 @@ class BaseUSV(Dynamics):
             "speed": PID(dt=kwargs["dt"], kp=0.8, ki=0.11, kd=0.1, integral_max=0.07),
             "heading": PID(dt=kwargs["dt"], kp=0.5, ki=0.012, kd=0.1, integral_max=0.07)
         }
+        #defult 0 max accel means no cap
 
     def reset(self):
         """
@@ -305,7 +309,6 @@ class BaseUSV(Dynamics):
         Place agent at previous position.
         Do not change is_tagged, has_flag, or on_own_side.
         """
-
         prev_pos = self.prev_pos
         self.prev_pos = self.pos
         self.pos = prev_pos
@@ -393,9 +396,15 @@ class BaseUSV(Dynamics):
         next_speed *= 1 - ((abs(rudder) / 100) * self.turn_loss)
 
         # Clip new speed based on max acceleration and deceleration
-        if (next_speed - self.speed) / self.dt > self.max_acc:
+        if (
+            self.max_acc > 0 and
+            (next_speed - self.speed) / self.dt > self.max_acc
+        ):
             next_speed = self.speed + self.max_acc * self.dt
-        elif (self.speed - next_speed) / self.dt > self.max_dec:
+        elif (
+            self.max_dec > 0 and
+            (self.speed - next_speed) / self.dt > self.max_dec
+        ):
             next_speed = self.speed - self.max_dec * self.dt
 
         return next_speed
@@ -456,6 +465,103 @@ class BaseUSV(Dynamics):
         return new_pos, new_speed
 
 
+class Heron(BaseUSV):
+    """
+    Dynamics class for Clearpath Robotics Heron M300 USV (https://oceanai.mit.edu/autonomylab/pmwiki/pmwiki.php?n=Robot.Heron).
+    
+    Parameters for dynamics and control were provided by the MIT Marine Autonomy Lab (https://oceanai.mit.edu/pavlab/pmwiki/pmwiki.php):
+        -max_speed
+            *max(thrust_map[1])
+        -thrust_map
+        -max_thrust
+        -max_rudder
+        -turn_rate
+        -speed PID gains
+        -heading (yaw) PID gains 
+    """
+    def __init__(
+        self,
+        max_speed:float = 2.0, # meters / s
+        thrust_map:np.ndarray = np.array( # piecewise linear mapping from desired_thrust to speed
+            [[0, 40, 100], [0, 1, 2]]
+        ),
+        max_thrust:float = 100, # limit on vehicle thrust
+        max_rudder:float = 100, # limit on vehicle rudder actuation
+        turn_rate:float = 60, # [0, 100] affecting vehicle turn radius, e.g., 0 is an infinite turn radius
+        **kwargs
+    ):
+        super().__init__(
+            max_speed=max_speed,
+            thrust_map=thrust_map,
+            max_thrust=max_thrust,
+            max_rudder=max_rudder,
+            turn_rate=turn_rate,
+            **kwargs
+        )
+
+        # PID 
+        self._pid_controllers = {
+            "speed": PID(dt=kwargs["dt"], kp=1.0, ki=0.0, kd=0.0, integral_max=0.07),
+            "heading": PID(dt=kwargs["dt"], kp=0.9, ki=0.3, kd=0.6, integral_max=0.3)
+        }
+
+
+class Surveyor(BaseUSV):
+    """
+    Dynamics class for SeaRobotics SR-Surveyor M1.8 USV (https://www.searobotics.com/products/autonomous-surface-vehicles/sr-surveyor-class).
+    
+    Parameters for dynamics and control are adapted from MOOS-IVP software/docs and missions:
+        (1) https://oceanai.mit.edu/svn/moos-ivp-aquaticus-oai/trunk/missions/wp_2024/surveyor/meta_surveyor.moos
+            -max_thrust
+            -max_rudder
+            -speed PID gains
+            -heading (yaw) PID gains
+
+        (2) https://oceanai.mit.edu/svn/moos-ivp-aquaticus-oai/trunk/missions/wp_2024/surveyor/plug_uSimMarine.moos
+            -max_speed
+                *max(thrust_map[1])
+            -thrust_map
+                *top speed changed from 2.75 to 3.0 based on wp_2024 experimental data
+            -turn_rate
+            -max_acc
+            -max_dec
+            -rotate_speed
+                *changed from 1.0 to 0.0 to assume equal thruster capabilites in simulation   
+    """
+    def __init__(
+        self,
+        max_speed:float = 3.0, # meters / s
+        thrust_map:np.ndarray = np.array( # piecewise linear mapping from desired_thrust to speed
+            [[-100, 0, 20,  40,  60,   70, 100],
+             [-2.0, 0,  1, 1.5, 2.0, 2.25, 3.0]]
+        ),
+        max_thrust:float = 100, # limit on vehicle thrust
+        max_rudder:float = 100, # limit on vehicle rudder actuation
+        turn_rate:float = 10, # [0, 100] affecting vehicle turn radius, e.g., 0 is an infinite turn radius
+        max_acc:float = 0.15, # [0, inf) meters / s**2
+        max_dec:float = 0.25, # [0, inf) meters / s**2
+        rotate_speed:float = 0.0, # deg/sec (attempt at a thruster bias to account for different thruster capabilities on hardware)
+        **kwargs
+    ):
+        super().__init__(
+            max_speed=max_speed,
+            thrust_map=thrust_map,
+            max_thrust=max_thrust,
+            max_rudder=max_rudder,
+            turn_rate=turn_rate,
+            max_acc=max_acc,
+            max_dec=max_dec,
+            rotate_speed=rotate_speed,
+            **kwargs
+        )
+
+        # PID 
+        self._pid_controllers = {
+            "speed": PID(dt=kwargs["dt"], kp=0.5, ki=0.0, kd=0.0, integral_max=0.00),
+            "heading": PID(dt=kwargs["dt"], kp=1.2, ki=0.0, kd=3.0, integral_max=0.00),
+        }
+
+
 class LargeUSV(BaseUSV):
     def __init__(
         self,
@@ -491,110 +597,6 @@ class LargeUSV(BaseUSV):
         self._pid_controllers = {
             "speed": PID(dt=kwargs["dt"], kp=1.0, ki=0.0, kd=0.0, integral_max=0.07),
             "heading": PID(dt=kwargs["dt"], kp=0.35, ki=0.0, kd=0.07, integral_max=0.07)
-        }
-
-
-class Heron(BaseUSV):
-    def __init__(
-        self,
-        max_speed: float = 1.5,  # meters / s
-        speed_factor: float = 20.0,  # multiplicative factor for desired_speed -> desired_thrust
-        thrust_map: np.ndarray = np.array(  # piecewise linear mapping from desired_thrust to speed
-            [[-100, 0, 20, 40, 60, 80, 100], [-2, 0, 1, 2, 3, 5, 5]]
-        ),
-        max_thrust: float = 70,  # limit on vehicle thrust
-        max_rudder: float = 100,  # limit on vehicle rudder actuation
-        turn_loss: float = 0.85,
-        turn_rate: float = 70,
-        max_acc: float = 1,  # meters / s**2
-        max_dec: float = 1,  # meters / s**2
-        **kwargs
-    ):
-        super().__init__(
-            max_speed=max_speed,
-            speed_factor=speed_factor,
-            thrust_map=thrust_map,
-            max_thrust=max_thrust,
-            max_rudder=max_rudder,
-            turn_loss=turn_loss,
-            turn_rate=turn_rate,
-            max_acc=max_acc,
-            max_dec=max_dec,
-            **kwargs
-        )
-
-        # PID 
-        self._pid_controllers = {
-            "speed": PID(dt=kwargs["dt"], kp=1.0, ki=0.0, kd=0.0, integral_max=0.07),
-            "heading": PID(dt=kwargs["dt"], kp=0.35, ki=0.0, kd=0.07, integral_max=0.07)
-        }
-
-
-class Surveyor(BaseUSV):
-    """
-    Dynamics class for SeaRobotics SR-Surveyor M1.8 USV (https://www.searobotics.com/products/autonomous-surface-vehicles/sr-surveyor-class).
-    
-    Parameters for dynamics and control are adapted from MOOS-IVP software/docs and missions:
-        (1) https://oceanai.mit.edu/svn/moos-ivp-aquaticus-oai/trunk/missions/wp_2024/surveyor/meta_surveyor.moos
-            -speed_factor
-                *changed from default 20 to 0.0 because non-zero speed_factor overrides use of speed PID controller and thrust_map
-                *referred to as thrust_factor in:
-                    (a) https://oceanai.mit.edu/ivpman/pmwiki/pmwiki.php?n=IvPTools.USimMarine
-                    (b) https://oceanai.mit.edu/svn/moos-ivp-aro/trunk/ivp/src/dep_uSimMarine/uSimMarine.moos
-            -max_thrust
-            -max_rudder
-            -speed PID gains
-            -heading (yaw) PID gains
-
-        (2) https://oceanai.mit.edu/svn/moos-ivp-aquaticus-oai/trunk/missions/wp_2024/surveyor/plug_uSimMarine.moos
-            -max_speed
-                *max(thrust_map[1])
-            -thrust_map
-                *top speed changed from 2.75 to 3.0 based on wp_2024 experimental data
-            -turn_rate
-            -max_acc
-            -max_dec
-            -rotate_speed
-                *changed from 1.0 to 0.0 to assume equal thruster capabilites in simulation
-
-        (3) https://oceanai.mit.edu/ivpman/pmwiki/pmwiki.php?n=IvPTools.USimMarine
-            -turn_loss     
-    """
-    def __init__(
-        self,
-        max_speed:float = 3.0,  # meters / s
-        speed_factor:float = 0.0,  # [0,inf) scalar correlation between thrust and speed (default is 20)
-        thrust_map:np.ndarray = np.array(  # piecewise linear mapping from desired_thrust to speed
-            [[-100, 0, 20,  40,  60,   70, 100],
-             [-2.0, 0,  1, 1.5, 2.0, 2.25, 3.0]]
-        ),
-        max_thrust:float = 100,  # limit on vehicle thrust
-        max_rudder:float = 100,  # limit on vehicle rudder actuation
-        turn_loss:float = 0.85, # [0, 1] affecting speed lost during a turn
-        turn_rate:float = 10, # [0, 100] affecting vehicle turn radius, e.g., 0 is an infinite turn radius
-        max_acc:float = 0.15, # [0, inf) meters / s**2
-        max_dec:float = 0.25, # [0, inf) meters / s**2
-        rotate_speed:float = 0.0, # deg/sec (attempt at a thruster bias to account for different thruster capabilities on hardware)
-        **kwargs
-    ):
-        super().__init__(
-            max_speed=max_speed,
-            speed_factor=speed_factor,
-            thrust_map=thrust_map,
-            max_thrust=max_thrust,
-            max_rudder=max_rudder,
-            turn_loss=turn_loss,
-            turn_rate=turn_rate,
-            max_acc=max_acc,
-            max_dec=max_dec,
-            rotate_speed=rotate_speed,
-            **kwargs
-        )
-
-        # PID 
-        self._pid_controllers = {
-            "speed": PID(dt=kwargs["dt"], kp=0.5, ki=0.0, kd=0.0, integral_max=0.00),
-            "heading": PID(dt=kwargs["dt"], kp=1.2, ki=0.0, kd=3.0, integral_max=0.00),
         }
 
 

--- a/pyquaticus/dynamics/dynamics.py
+++ b/pyquaticus/dynamics/dynamics.py
@@ -238,34 +238,33 @@ class BaseUSV(Dynamics):
         (2) https://oceanai.mit.edu/svn/moos-ivp-aro/trunk/ivp/src/dep_uSimMarine/USM_Model.cpp
             -turn_rate
             -max_acc
-                *if 0, no limit on acceleration
             -max_decc
-                *if 0, no limit on decceleration
+            -rotate_speed 
 
         (3) https://oceanai.mit.edu/ivpman/pmwiki/pmwiki.php?n=IvPTools.USimMarine
             -max_speed
                 *max(thrust_map[1])
             -speed_factor
                 *also referred to as thrust_factor
-                *changed from default 20 to 0.0 because non-zero speed_factor overrides use of speed PID controller
+                *changed from default 20 to 0 because non-zero speed_factor overrides use of speed PID controller
             -thrust_map
                 *see section 8.5 for default thrust_map
-            -turn_loss
-            -rotate_speed  
+            -turn_loss 
     """
     def __init__(
         self,
         max_speed:float = 5.0,  # meters / s
         speed_factor:float = 0,  # [0,inf) scalar correlation between thrust and speed
-        thrust_map:np.ndarray = np.array(  # piecewise linear mapping from desired_thrust to speed
-            [[-100, 0, 100],[0, 0, 5]]
+        thrust_map:np.ndarray = np.array(  # piecewise linear mapping from desired_thrust to speed (meters/s)
+            [[0, 100],
+             [0,   5]]
         ),
         max_thrust:float = 100,  # limit on vehicle thrust
         max_rudder:float = 100,  # limit on vehicle rudder actuation
         turn_loss:float = 0.85,  # [0, 1] affecting speed lost during a turn
         turn_rate:float = 70,  # [0, 100] affecting vehicle turn radius, e.g., 0 is an infinite turn radius
-        max_acc:float = 0,  # [0, inf) meters / s**2
-        max_dec:float = 0.5,  # [0, inf) meters / s**2
+        max_acc:float = 0,  # meters / s**2 (if 0, no limit on acceleration)
+        max_dec:float = 0.5,  # meters / s**2 (if 0, no limit on decceleration)
         rotate_speed:float = 0,  # deg/sec (attempt at a thruster bias to account for different thruster capabilities on hardware)
         **kwargs
     ):
@@ -287,10 +286,9 @@ class BaseUSV(Dynamics):
 
         # PID 
         self._pid_controllers = {
-            "speed": PID(dt=kwargs["dt"], kp=0.8, ki=0.11, kd=0.1, integral_max=0.07),
-            "heading": PID(dt=kwargs["dt"], kp=0.5, ki=0.012, kd=0.1, integral_max=0.07)
+            "speed": PID(dt=kwargs["dt"], kp=0.8, ki=0.11, kd=0.1, integral_limit=0.07),
+            "heading": PID(dt=kwargs["dt"], kp=0.5, ki=0.012, kd=0.1, integral_limit=0.2)
         }
-        #defult 0 max accel means no cap
 
     def reset(self):
         """
@@ -367,6 +365,7 @@ class BaseUSV(Dynamics):
         else:
             speed_error = desired_speed - self.speed
             delta_thrust = self._pid_controllers['speed'](speed_error)
+            
             desired_thrust = self.state['thrust'] + delta_thrust
 
         if desired_thrust < 0.01:
@@ -481,13 +480,14 @@ class Heron(BaseUSV):
     """
     def __init__(
         self,
-        max_speed:float = 2.0, # meters / s
-        thrust_map:np.ndarray = np.array( # piecewise linear mapping from desired_thrust to speed
-            [[0, 40, 100], [0, 1, 2]]
+        max_speed:float = 2.0,
+        thrust_map:np.ndarray = np.array(
+            [[0, 40, 100],
+             [0,  1,   2]]
         ),
-        max_thrust:float = 100, # limit on vehicle thrust
-        max_rudder:float = 100, # limit on vehicle rudder actuation
-        turn_rate:float = 60, # [0, 100] affecting vehicle turn radius, e.g., 0 is an infinite turn radius
+        max_thrust:float = 100,
+        max_rudder:float = 100,
+        turn_rate:float = 60,
         **kwargs
     ):
         super().__init__(
@@ -501,8 +501,22 @@ class Heron(BaseUSV):
 
         # PID 
         self._pid_controllers = {
-            "speed": PID(dt=kwargs["dt"], kp=1.0, ki=0.0, kd=0.0, integral_max=0.07),
-            "heading": PID(dt=kwargs["dt"], kp=0.9, ki=0.3, kd=0.6, integral_max=0.3)
+            "speed": PID(
+                dt=kwargs["dt"],
+                kp=1.0,
+                ki=0.0,
+                kd=0.0,
+                integral_limit=0.07,
+                output_limit=max_thrust
+            ),
+            "heading": PID(
+                dt=kwargs["dt"],
+                kp=0.9,
+                ki=0.3,
+                kd=0.6,
+                integral_limit=0.3,
+                output_limit=max_rudder
+            )
         }
 
 
@@ -530,17 +544,17 @@ class Surveyor(BaseUSV):
     """
     def __init__(
         self,
-        max_speed:float = 3.0, # meters / s
-        thrust_map:np.ndarray = np.array( # piecewise linear mapping from desired_thrust to speed
+        max_speed:float = 3.0,
+        thrust_map:np.ndarray = np.array(
             [[-100, 0, 20,  40,  60,   70, 100],
              [-2.0, 0,  1, 1.5, 2.0, 2.25, 3.0]]
         ),
-        max_thrust:float = 100, # limit on vehicle thrust
-        max_rudder:float = 100, # limit on vehicle rudder actuation
-        turn_rate:float = 10, # [0, 100] affecting vehicle turn radius, e.g., 0 is an infinite turn radius
-        max_acc:float = 0.15, # [0, inf) meters / s**2
-        max_dec:float = 0.25, # [0, inf) meters / s**2
-        rotate_speed:float = 0.0, # deg/sec (attempt at a thruster bias to account for different thruster capabilities on hardware)
+        max_thrust:float = 100,
+        max_rudder:float = 100,
+        turn_rate:float = 10,
+        max_acc:float = 0.15,
+        max_dec:float = 0.25,
+        rotate_speed:float = 0.0,
         **kwargs
     ):
         super().__init__(
@@ -557,28 +571,41 @@ class Surveyor(BaseUSV):
 
         # PID 
         self._pid_controllers = {
-            "speed": PID(dt=kwargs["dt"], kp=0.5, ki=0.0, kd=0.0, integral_max=0.00),
-            "heading": PID(dt=kwargs["dt"], kp=1.2, ki=0.0, kd=3.0, integral_max=0.00),
+            "speed": PID(
+                dt=kwargs["dt"],
+                kp=0.5,
+                ki=0.0,
+                kd=0.0,
+                integral_limit=0.00,
+                output_limit=max_thrust
+            ),
+            "heading": PID(
+                dt=kwargs["dt"],
+                kp=1.2,
+                ki=0.0,
+                kd=3.0,
+                integral_limit=0.00,
+                output_limit=max_rudder
+            )
         }
 
 
 class LargeUSV(BaseUSV):
     def __init__(
         self,
-        max_speed: float = 12,  # meters / s
-        speed_factor: float = (
-            20.0 / 3
-        ),  # multiplicative factor for desired_speed -> desired_thrust
-        thrust_map: np.ndarray = np.array(  # piecewise linear mapping from desired_thrust to speed
-            [[-100, 0, 20, 40, 60, 80, 100], [-3, 0, 3, 6, 9, 12, 12]]
+        max_speed: float = 12,
+        speed_factor: float = (20.0 / 3),
+        thrust_map: np.ndarray = np.array(
+            [[-100, 0, 20, 40, 60, 80, 100],
+             [  -3, 0,  3,  6,  9, 12,  12]]
         ),
-        max_thrust: float = 70,  # limit on vehicle thrust
-        max_rudder: float = 100,  # limit on vehicle rudder actuation
+        max_thrust: float = 70,
+        max_rudder: float = 100,
         turn_loss: float = 0.85,
         turn_rate: float = 50,
-        max_acc: float = 0.5,  # meters / s**2
-        max_dec: float = 0.5,  # meters / s**2
-        **kwargs,
+        max_acc: float = 0.5,
+        max_dec: float = 0.5,
+        **kwargs
     ):
         super().__init__(
             max_speed=max_speed,
@@ -595,8 +622,8 @@ class LargeUSV(BaseUSV):
 
         # PID
         self._pid_controllers = {
-            "speed": PID(dt=kwargs["dt"], kp=1.0, ki=0.0, kd=0.0, integral_max=0.07),
-            "heading": PID(dt=kwargs["dt"], kp=0.35, ki=0.0, kd=0.07, integral_max=0.07)
+            "speed": PID(dt=kwargs["dt"], kp=1.0, ki=0.0, kd=0.0, integral_limit=0.07),
+            "heading": PID(dt=kwargs["dt"], kp=0.35, ki=0.0, kd=0.07, integral_limit=0.07)
         }
 
 

--- a/pyquaticus/utils/pid.py
+++ b/pyquaticus/utils/pid.py
@@ -19,32 +19,45 @@
 
 # SPDX-License-Identifier: BSD-3-Clause
 
-
+import numpy as np
 
 # Adapted from MOOS-IvP ScalarPID and PIDEngine:
 # https://oceanai.mit.edu/svn/moos-ivp-aro/trunk/ivp/src/lib_marine_pid/ScalarPID.cpp
 # https://oceanai.mit.edu/svn/moos-ivp-aro/trunk/ivp/src/lib_marine_pid/PIDEngine.cpp
+
+# Note: the full moos implementatiion includes noise filtering based on the derivative term history.
+# For our simulation purposes, this is not needed.
+
 class PID:
     """Simple class for scalar PID control."""
-    # The full moos implementatiion includes noise filtering. For our simulation purposes, this is not needed.
-    def __init__(self, dt, kp, ki, kd, integral_max=float("inf")):
+    def __init__(self, dt, kp, ki, kd, integral_limit=float("inf"), output_limit=float("inf")):
         self._dt = dt
         self._kp = kp
         self._ki = ki
         self._kd = kd
-        self._integral_max = integral_max
+        self._integral_limit = integral_limit
+        self._output_limit = output_limit
 
+        self._n_iterations = 0
         self._prev_error = 0.0
         self._integral = 0.0
 
     def __call__(self, error):
-        self._integral = min(self._integral + error * self._dt, self._integral_max)
-        deriv = (error - self._prev_error) / self._dt
+        #Calculate the derivative term
+        if self._n_iterations != 0:
+            deriv = (error - self._prev_error) / self._dt
+        else:
+            deriv = 0
 
+        #Calculate the integral term
+        self._integral += self._ki * error * self._dt
+        self._integral = np.clip(self._integral, -self._integral_limit, self._integral_limit) #prevent integral wind up
+        
+        #Calculate PID output
+        pid_out = (self._kp * error) + (self._kd * deriv) + self._integral #note Ki is already in self._integral
+        pid_out = np.clip(pid_out, -self._output_limit, self._output_limit) #prevent saturation
+        
         self._prev_error = error
+        self._n_iterations += 1
 
-        p = self._kp * error
-        i = self._ki * self._integral
-        d = self._kd * deriv
-
-        return p + i + d
+        return pid_out

--- a/test/dynamics_test.py
+++ b/test/dynamics_test.py
@@ -183,8 +183,8 @@ def main():
     config["render_agent_ids"] = True
     config["render_traj_mode"] = "traj"
     config["render_traj_cutoff"] = 100
-    config["dynamics"] = ["surveyor", "surveyor"]#si
-    config["render_saving"] = False
+    config["tag_on_oob"] = False
+    config["dynamics"] = ["surveyor", "surveyor"]
     # config["lidar_obs"] = True
     # config["render_lidar_mode"] = "detection"
     # config["lidar_range"] = 20


### PR DESCRIPTION
- Added lower bound for integral term in [scalar PID controller](https://github.com/mit-ll-trusted-autonomy/pyquaticus/blob/main/pyquaticus/utils/pid.py) to prevent negative wind up bug
- Clipping on scalar PID output
- Adjusted Heron dynamics and PID parameters after consulting the MIT Marine Autonomy lab 